### PR TITLE
feat: add agent configuration

### DIFF
--- a/NewRelic.Xamarin.Plugin/AgentStartConfiguration.shared.cs
+++ b/NewRelic.Xamarin.Plugin/AgentStartConfiguration.shared.cs
@@ -1,0 +1,37 @@
+﻿using System;
+namespace Plugin.NewRelicClient
+{
+
+    public enum LogLevel
+    {
+        ERROR,
+        WARNING,
+        INFO,
+        VERBOSE,
+        AUDIT
+    }
+
+    public class AgentStartConfiguration
+    {
+        public bool crashReportingEnabled = true;
+        public bool loggingEnabled = true;
+        public LogLevel logLevel = LogLevel.INFO;
+        public string collectorAddress = "DEFAULT";
+        public string crashCollectorAddress = "DEFAULT";
+
+        public AgentStartConfiguration()
+        {
+        }
+
+        public AgentStartConfiguration(bool crashReportingEnabled, bool loggingEnabled, LogLevel logLevel, string collectorAddress, string crashCollectorAddress)
+        {
+            this.crashReportingEnabled = crashReportingEnabled;
+            this.loggingEnabled = loggingEnabled;
+            this.logLevel = logLevel;
+            this.collectorAddress = collectorAddress;
+            this.crashCollectorAddress = crashCollectorAddress;
+        }
+    }
+
+}
+

--- a/NewRelic.Xamarin.Plugin/INewRelicClientManager.shared.cs
+++ b/NewRelic.Xamarin.Plugin/INewRelicClientManager.shared.cs
@@ -16,7 +16,7 @@ namespace Plugin.NewRelicClient
     public interface INewRelicClientManager
     {
 
-        void Start(string applicationToken);
+        void Start(string applicationToken, AgentStartConfiguration agentConfig = null);
 
         void CrashNow(string message = "");
 

--- a/NewRelic.Xamarin.iOS.Binding/ApiDefinitions.cs
+++ b/NewRelic.Xamarin.iOS.Binding/ApiDefinitions.cs
@@ -162,6 +162,11 @@ namespace NewRelicXamarinIOS
 		[Export ("setPlatform:")]
 		void SetPlatform (NRMAApplicationPlatform platform);
 
+		// +(void)setPlatformVersion:(NSString * _Nonnull)platformVersion;
+		[Static]
+		[Export("setPlatformVersion:")]
+		void SetPlatformVersion(string platformVersion);
+
 		// +(NSString * _Null_unspecified)currentSessionId;
 		[Static]
 		[Export ("currentSessionId")]

--- a/NewRelic.Xamarin.iOS.Binding/Podfile
+++ b/NewRelic.Xamarin.iOS.Binding/Podfile
@@ -6,4 +6,4 @@ target 'ObjectiveSharpieIntegration' do
   use_frameworks!
 end
 
-pod 'NewRelicAgent', '7.4.3'
+pod 'NewRelicAgent', '7.4.4'

--- a/README.md
+++ b/README.md
@@ -46,12 +46,18 @@ using Plugin.NewRelicClient;
       Application.Current.PageDisappearing += PageDisappearing;
 
       CrossNewRelicClient.Current.HandleUncaughtException();
-      if (Device.RuntimePlatform == Device.iOS)
+      // Set optional agent configuration
+      // AgentStartConfiguration agentConfig = new AgentStartConfiguration(true, true, LogLevel.INFO, "mobile-collector.newrelic.com", "mobile-crash.newrelic.com");
+      if (Device.RuntimePlatform == Device.Android) 
       {
-          CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
-      } else if (Device.RuntimePlatform == Device.Android)
+        CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration 
+        // CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
+      } else if (Device.RuntimePlatform == Device.iOS)
       {
-          CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
+        CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration 
+        // CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
       }
     }
 


### PR DESCRIPTION
- Added agent configuration options on start
    - User can opt to not add `AgentStartConfiguration` object on start call for default settings
    - Default settings are all true, log level info, and default collector addresses
- Removed `Console.WriteLine(...)` statements
- Added `SetPlatformVersion` to iOS binding and added set platform version on `Start`