### PR TITLE
feat: add navigation instrumentation

### DIFF
--- a/NewRelic.Xamarin.Plugin/INewRelicClientManager.shared.cs
+++ b/NewRelic.Xamarin.Plugin/INewRelicClientManager.shared.cs
@@ -73,7 +73,7 @@ namespace NewRelic.Xamarin.Plugin
 
         void HandleUncaughtException(bool shouldThrowFormattedException = true);
 
-
+        void TrackShellNavigatedEvents();
 
     }
 

--- a/NewRelic.Xamarin.Plugin/NewRelic.Xamarin.Plugin.csproj
+++ b/NewRelic.Xamarin.Plugin/NewRelic.Xamarin.Plugin.csproj
@@ -43,6 +43,9 @@
 		<Company>NewRelic</Company>
 	</PropertyGroup>
 	<ItemGroup>
+		<Reference Include="netstandard" />
+	</ItemGroup>
+	<ItemGroup>
 		<Compile Include="**\*.shared.cs" />
 		<Compile Include="**\*.shared.*.cs" />
 	</ItemGroup>
@@ -61,5 +64,8 @@
 	<ItemGroup>
 		<None Remove="Mono.Android" />
 		<None Remove="Xamarin.Forms" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Xamarin.Forms" Version="5.0.0.2578" />
 	</ItemGroup>
 </Project>

--- a/NewRelic.Xamarin.Plugin/NewRelicClientManager.android.cs
+++ b/NewRelic.Xamarin.Plugin/NewRelicClientManager.android.cs
@@ -13,8 +13,7 @@ using NRAndroidAgent = Com.Newrelic.Agent.Android.NewRelic;
 using System.Collections.Generic;
 using System.Net.Http;
 using Android.Runtime;
-
-
+using Xamarin.Forms;
 
 namespace NewRelic.Xamarin.Plugin
 {
@@ -324,6 +323,21 @@ namespace NewRelic.Xamarin.Plugin
             };
 
             AndroidEnvironment.UnhandledExceptionRaiser += _handler;
+        }
+
+        public void TrackShellNavigatedEvents()
+        {
+            Shell.Current.Navigated += (sender, e) =>
+            {
+                Dictionary<string, object> attr = new Dictionary<string, object>();
+                if (e.Previous != null)
+                {
+                    attr.Add("Previous", e.Previous.Location.ToString());
+                }
+                attr.Add("Current", e.Current.Location.ToString());
+                attr.Add("Source", e.Source.ToString());
+                this.RecordBreadcrumb("ShellNavigated", attr);
+            };
         }
 
     }

--- a/NewRelic.Xamarin.Plugin/NewRelicClientManager.apple.cs
+++ b/NewRelic.Xamarin.Plugin/NewRelicClientManager.apple.cs
@@ -12,6 +12,7 @@ using UIKit;
 using NRIosAgent = NewRelicXamarinIOS.NewRelic;
 using System.Collections.Generic;
 using System.Net.Http;
+using Xamarin.Forms;
 
 namespace NewRelic.Xamarin.Plugin
 {
@@ -291,7 +292,22 @@ namespace NewRelic.Xamarin.Plugin
                 };
             }
         
-    }
+        }
+
+        public void TrackShellNavigatedEvents()
+        {
+            Shell.Current.Navigated += (sender, e) =>
+            {
+                Dictionary<string, object> attr = new Dictionary<string, object>();
+                if (e.Previous != null)
+                {
+                    attr.Add("Previous", e.Previous.Location.ToString());
+                }
+                attr.Add("Current", e.Current.Location.ToString());
+                attr.Add("Source", e.Source.ToString());
+                this.RecordBreadcrumb("ShellNavigated", attr);
+            };
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ using NewRelic.Xamarin.Plugin;
       Application.Current.PageDisappearing += PageDisappearing;
 
       CrossNewRelicClient.Current.HandleUncaughtException();
+      CrossNewRelicClient.Current.TrackShellNavigatedEvents()
       // Set optional agent configuration
+      // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress
       // AgentStartConfiguration agentConfig = new AgentStartConfiguration(true, true, LogLevel.INFO, "mobile-collector.newrelic.com", "mobile-crash.newrelic.com");
       if (Device.RuntimePlatform == Device.Android) 
       {
         CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
-        // Start with optional agent configuration 
+        // Start with optional agent configuration
         // CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
       } else if (Device.RuntimePlatform == Device.iOS)
       {
@@ -75,7 +77,22 @@ using NewRelic.Xamarin.Plugin;
 
 ## Screen Tracking Events
 
-:construction: WORK IN PROGRESS :construction:
+The Xamarin mobile plugin allows you to track navigation events within the [.NET MAUI Shell](https://learn.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/shell/). In order to do so, you only need to call:
+
+```C#
+    CrossNewRelicClient.Current.TrackShellNavigatedEvents();
+```
+
+It is recommended to call this method along when starting the agent. These events will only be recorded after navigation is complete. You can find this data through the data explorer in `MobileBreadcrumb` under the name `ShellNavigated` or by query:
+
+```sql
+    SELECT * FROM MobileBreadcrumb WHERE name = 'ShellNavigated' SINCE 24 HOURS AGO
+```
+
+The breadcrumb will contain three attributes:
+* `Current`: The URI of the current page.
+* `Source`: The type of navigation that occurred.
+* `Previous`: The URI of the previous page. Will not exist if previous page was null. 
 
 
 ## Usage


### PR DESCRIPTION
This PR uses shell navigated event handler and adds a `ShellNavigated` breadcrumb with the data in the `ShellNavigatedEventArgs` object in the `Navigated` event. It will record a breadcrumb _**after**_ a navigation event has occurred. It will contain the URI of current page, URI of previous page (none if on first load or is null), and the source of the navigation. 

- Adds reference to `netstandard` and `Xamarin.Forms` in order to access the shell navigated events